### PR TITLE
Include 'posted' field for '/messages' endpoint

### DIFF
--- a/app/controllers/api/v1/devices_controller.rb
+++ b/app/controllers/api/v1/devices_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::DevicesController < ApplicationController
+  skip_before_action :verify_authenticity_token
 
   def create
     @device = Device.create!(device_params)

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -2,12 +2,15 @@ class Api::V1::MessagesController < ApplicationController
 
   def index
     @messages = Message.posted.order(updated_at: :desc)
+    if params[:posted].present? && !ActiveModel::Type::Boolean.new.cast(params[:posted])
+      @messages = Message.unposted.order(updated_at: :desc)
+    end
 
     result = @messages.map do |msg|
-      {
-        id: msg.id,
+      { id: msg.id,
         title: { en: msg.title, es: msg.titulo },
         body:  { en: msg.body,  es: msg.cuerpo },
+        posted: msg.posted,
         message_type: msg.message_type,
         updated_at: msg.updated_at
       }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,5 +3,6 @@ class Message < ApplicationRecord
 
   # default_scope { order(created_at: :desc) }
   scope :posted, -> { where(posted: true) }
+  scope :unposted, -> { where(posted: false) }
 
 end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -1,17 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe 'Messages API', type: :request do
-  let!(:message) { create :message }
+  let!(:message) { create_list :message, 2 }
+  let!(:message1) { create_list :message, 5, posted: false }
 
   describe "GET /messages" do
     before { get '/api/v1/messages' }
 
     it "returns messages" do
       expect(json).not_to be_empty
-      expect(json.size).to be(1)
+      expect(json.size).to be(2)
       expect(json[0]['title']['en']).to eq('Severe Storms Threats!')
       expect(json[0]['title']['es']).to eq('Amenazas de tormentas severas!')
-      expect(json[0]['posted']).to be_nil
+      expect(json[0]['posted']).to be_truthy
+    end
+
+    it 'returns status code 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "GET /messages with params posted" do
+    before { get '/api/v1/messages', params: { posted: false } }
+
+    it "returns messages" do
+      expect(json).not_to be_empty
+      expect(json.size).to be(5)
+      expect(json[0]['title']['en']).to eq('Severe Storms Threats!')
+      expect(json[0]['title']['es']).to eq('Amenazas de tormentas severas!')
+      expect(json[0]['posted']).to be_falsy
     end
 
     it 'returns status code 200' do


### PR DESCRIPTION
- Modified GET '/messages' endpoint by adding posted params
- Included `posted` field as well for the endpoint
@micronix !