### PR TITLE
Style admin list of messages

### DIFF
--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -75,7 +75,7 @@
 }
 
 #active-link {
-  border: dotted 1px black;
+  border: dotted 1px #8a6d3b;
 }
 
 .fa-icon-success {

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -16,11 +16,13 @@
   border: none;
 }
 
+.messages {
+  border-bottom: 1px solid #8a6d3b;
+}
 .message {
   position: relative;
-  background-color: white;
-  border: 2px solid gray;
-  box-shadow: .5px .5px 1px 1px lightgray;
+  border: 1px solid #8a6d3b;
+  border-bottom: none;
 }
 
 .button_to {
@@ -50,11 +52,11 @@
 #buttons {
   display: flex;
   flex-direction: row;
-  align-items: center;
+  justify-content: flex-end;
 }
 
 .row1 {
-  height: 60px;
+  height: auto;
   display: flex;
   align-items: center;
   border-bottom: none;
@@ -62,6 +64,14 @@
 
 .row1:hover {
   background-color: #D6DBDF;
+}
+
+.edit-delete-buttons {
+  display: none;
+}
+
+.row1:hover .edit-delete-buttons {
+  display: block;
 }
 
 #active-link {

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -63,7 +63,7 @@
 }
 
 .row1:hover {
-  background-color: #D6DBDF;
+  background-color: LightYellow;
 }
 
 .edit-delete-buttons {

--- a/app/controllers/agencies_controller.rb
+++ b/app/controllers/agencies_controller.rb
@@ -1,3 +1,5 @@
+require 'rails_rinku'
+
 class AgenciesController < ApplicationController
   before_action :authenticate_user!, except: %i[show index]
   after_action :verify_authorized, except: %i[show index]

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,5 @@
 class MessagesController < ApplicationController
-  before_action :set_message, only: [:edit, :update, :destroy, :post, :unpost]
+  before_action :set_message, only: [:show, :edit, :update, :destroy, :post, :unpost]
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   after_action  :verify_authorized
 
@@ -31,6 +31,10 @@ class MessagesController < ApplicationController
     else
       render 'new'
     end
+  end
+
+  def show
+    authorize @message
   end
 
   def edit

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,2 +1,7 @@
 module MessagesHelper
+
+  # def strip_url(url)
+  #   return url.to_s.sub!(/https?(\:)?(\/)?(\/)?(www\.)?/, '') if url.include?("http")
+  #   url.to_s.sub!(/(www\.)?/,'') if url.include?("www")
+  # end
 end

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -14,6 +14,11 @@ class MessagePolicy < ApplicationPolicy
     @user.admin?
   end
 
+  def show?
+    return false if @current_user == @user
+    @user.admin?
+  end
+
   def destroy?
     return false if @current_user == @user
     @user.admin?

--- a/app/views/agencies/index.html.erb
+++ b/app/views/agencies/index.html.erb
@@ -1,5 +1,3 @@
-<% require 'rails_rinku' %>
-
 <% content_for :title do %><%=  (t'nav_links.home') %> | Conectate Carolina<% end %>
 
 <script src="//maps.google.com/maps/api/js?key=AIzaSyCj5WxwF7qYcjlvsjtzabyVi0Se1WtuA6w"></script>
@@ -40,9 +38,7 @@ getLocation();
           <div class="left">
             <h4><b><%= @message.title %></b></h4>
             <p class="auto-links">
-              <%= auto_link(@message.body, html: { target: '_blank' }) do |url| %>
-                <% "link" %>
-              <% end %>
+              <%= auto_link(@message.body, html: { target: '_blank' }) %>
             </p>
           </div>
           <div class="remove"><button id="my_x_button"><%= fa_icon "times" %></button></div>
@@ -52,9 +48,7 @@ getLocation();
         <div class="left">
           <h4><b><%= @message.titulo %></b></h4>
           <p class="auto-links">
-            <%= auto_link(@message.cuerpo, html: { target: '_blank' }) do |url| %>
-              <% "link" %>
-            <% end %>
+            <%= auto_link(@message.cuerpo, html: { target: '_blank' }) %>
           </p>
         </div>
         <div class="remove"><button><%= fa_icon "times" %></button></div>

--- a/app/views/messages/_messages.html.erb
+++ b/app/views/messages/_messages.html.erb
@@ -28,8 +28,8 @@
               </div>
             <% end %>
             <div class="msg-content">
-              <p><b><%= message.title %></b><br/>
-              <%= message.body %></p>
+              <h4><b><%= message.title %></b></h4>
+              <p class="auto-links"><%= auto_link(truncate(message.body, length: 90){ link_to "read more", message_path(message) }, html: {target: '_blank'}) %></p>
             </div>
           </div>
           <div class="controls col-sm-5 col-md-3", id="buttons">

--- a/app/views/messages/_messages.html.erb
+++ b/app/views/messages/_messages.html.erb
@@ -33,7 +33,7 @@
             </div>
           </div>
           <div class="controls col-sm-5 col-md-3", id="buttons">
-            <div>
+            <div class="edit-delete-buttons">
               <%= link_to edit_message_path(message), class: "btn btn-sm btn-secondary" do %>
                 <i class="fa fa-pencil-square-o">Edit</i>
               <% end %>

--- a/app/views/messages/_messages.html.erb
+++ b/app/views/messages/_messages.html.erb
@@ -29,7 +29,7 @@
             <% end %>
             <div class="msg-content">
               <h4><b><%= message.title %></b></h4>
-              <p class="auto-links"><%= auto_link(truncate(message.body, length: 90){ link_to "read more", message_path(message) }, html: {target: '_blank'}) %></p>
+              <p class="auto-links"><%= truncate(message.body, length: 90){ link_to " read more", message_path(message) } %></p>
             </div>
           </div>
           <div class="controls col-sm-5 col-md-3", id="buttons">

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,0 +1,7 @@
+<div class="jumbotron" style="margin-top: 20px">
+  <h2><%= @message.title%></h2>
+  <p><%= auto_link(@message.body, html: {target: '_blank'}) %></p>
+  <%= link_to "Back", messages_path, class: "btn btn-primary" %>
+  <%= link_to "Edit", edit_message_path(@message), class: "btn btn-secondary" %>
+  <%= link_to "Delete", message_path(@message), method: :delete, data: { confirm: "You sure?" }, class: "btn btn-secondary" %>
+</div>


### PR DESCRIPTION
- Styled admin's list of messages
   - Fix content overflow from row by providing row-height `auto`
   - Changed hover over color to `LightYellow`
   - Made such that the `Edit` and `Delete` buttons are displayed only on hover over the row
- Made changes to `auto_link` urls
   - Removed `link` text that referenced the actual url. It displays the actual url now
@jrmcgarvey @micronix !
