### PR TITLE
Remove default for message_type 

### DIFF
--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -39,7 +39,7 @@
   <div class="form-group required">
     <%= f.label  :message_type, class: 'control-label col-md-4' %>
     <div class="controls col-md-8">
-      <%= f.select(:message_type, options_for_select(['success', 'info', 'warning', 'danger'], 'success')) %>
+      <%= f.select(:message_type, options_for_select(['success', 'info', 'warning', 'danger'], "#{@message.message_type}")) %>
     </div>
   </div>
 

--- a/db/migrate/20190918161756_remove_default_message_type_from_messages.rb
+++ b/db/migrate/20190918161756_remove_default_message_type_from_messages.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultMessageTypeFromMessages < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default(:messages, :message_type, nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_23_205353) do
+ActiveRecord::Schema.define(version: 2019_09_18_161756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 2019_08_23_205353) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "posted", default: false
-    t.string "message_type", default: "info"
+    t.string "message_type"
     t.string "titulo"
     t.text "cuerpo"
     t.datetime "posted_at"


### PR DESCRIPTION
- Removed message_type default that always defaulted to `success` on `edit` form
@jrmcgarvey @micronix 

Thanks!