### PR TITLE
Spanish translation of privacy policy

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,13 @@ class PagesController < ApplicationController
   def privacy_policy
   end
 
+  def en_privacy_policy
+  end
+
   def terms_and_conditions
+  end
+
+  def en_terms_and_conditions
   end
 
   def mobile_page

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -92,5 +92,21 @@
     </div>
 </div>
 <div class="footer-copyright">
-    <p>© 2017 Copyright</p><p>.</p><p><%= link_to (t'pages.privacy'), pages_privacy_policy_path, class: "privacy" %></p><p>.</p><p><%= link_to (t'pages.tac'), pages_terms_and_conditions_path, class: "privacy"%></p>
+    <p>© 2017 Copyright</p>
+    <p>.</p>
+    <p>
+      <% if locale == :en %>
+        <%= link_to 'Privacy Policy', pages_en_privacy_policy_path, class: "privacy" %>
+      <% elsif locale == :es %>
+        <%= link_to 'Póliza de Privacidad', pages_privacy_policy_path, class: "privacy" %>
+      <% end %>
+    </p>
+    <p>.</p>
+    <p>
+      <% if locale == :en %>
+        <%= link_to 'Terms and Conditions', pages_en_terms_and_conditions_path, class: "privacy"%>
+      <% elsif locale == :es %>
+        <%= link_to 'Términos y Condiciones', pages_terms_and_conditions_path, class: "privacy"%>
+      <% end %>
+    </p>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -92,5 +92,5 @@
     </div>
 </div>
 <div class="footer-copyright">
-    <p>© 2017 Copyright</p><p>.</p><p><%= link_to "Privacy Policy", pages_privacy_policy_path, class: "privacy" %></p><p>.</p><p><%= link_to "Terms and Conditions", pages_terms_and_conditions_path, class: "privacy"%></p>
+    <p>© 2017 Copyright</p><p>.</p><p><%= link_to (t'pages.privacy'), pages_privacy_policy_path, class: "privacy" %></p><p>.</p><p><%= link_to (t'pages.tac'), pages_terms_and_conditions_path, class: "privacy"%></p>
 </div>

--- a/app/views/pages/en_privacy_policy.html.erb
+++ b/app/views/pages/en_privacy_policy.html.erb
@@ -1,0 +1,107 @@
+<div class="container" id="pages">
+  <h2 class="page-heading">Privacy Policy</h2>
+  <p>
+    Student Action with Farmworkers built the Conectate Carolina app as a Free app.
+    This SERVICE is provided by Student Action with Farmworkers at no cost and is intended for use as is.
+  </p>
+  <p>
+    This page is used to inform visitors regarding our policies with the collection, use,
+    and disclosure of Personal Information if anyone decided to use our Service.
+  </p>
+  <p>
+    If you choose to use our Service, then you agree to the collection and use of informationin relation to this policy.
+     The Personal Information that we collect is used for providing and improving the Service.
+     We will not use or share your information with anyone except as described in this Privacy Policy.
+  </p>
+  <p>
+    The terms used in this Privacy Policy have the same meanings as in our Terms and Conditions,
+    which is accessible at Conectate Carolina unless otherwise defined in this Privacy Policy.
+  </p>
+  <p><strong>Information Collection and Use</strong></p>
+  <p>
+    For a better experience, while using our Service, we may require you to provide us with certain personally identifiable
+    information, including but not limited to your location as identified by your GPS provider, wifi connection, and/or cellular towers.
+  </p>
+  <p>
+    The information that we request will be retained by us and used as described in this privacy policy.
+  </p>
+  <p>
+    The app does use third party services that may collect information used to identify you.
+  </p>
+  <div>
+    <p>
+      Link to privacy policy of third party service providers used by the app:
+    </p>
+      <ul>
+        <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+      </ul>
+      </div><p><strong>Log Data</strong></p>
+      <p>
+        We want to inform you that whenever
+        you use our Service, in a case of an error in the
+        app we collect data and information (through third
+        party products) on your phone called Log Data. This Log Data
+        may include information such as your device Internet
+        Protocol (“IP”) address, device name, operating system
+        version, the configuration of the app when utilizing
+        our Service, the time and date of your use of the
+        Service, and other statistics.
+      </p>
+  <p><strong>Cookies</strong></p>
+  <p>
+    Cookies are files with a small amount of data that are
+    commonly used as anonymous unique identifiers. These are sent to your
+    browser from the websites that you visit and are stored on your device's internal memory.
+  </p>
+  <p>
+    This Service does not use these “cookies” explicitly. However, the app may
+    use third party code and libraries that use “cookies” to collect information and
+    improve their services. You have the option to either accept or refuse these cookies
+    and know when a cookie is being sent to your device. If you choose to refuse our cookies,
+    you may not be able to use some portions of this Service.
+  </p>
+  <p><strong>Service Providers</strong></p>
+  <p>
+    We may employ third-party companies
+    and individuals due to the following reasons:
+  </p>
+  <ul>
+    <li>To facilitate our Service;</li>
+    <li>To provide the Service on our behalf;</li>
+    <li>To perform Service-related services; or</li>
+    <li>To assist us in analyzing how our Service is used.</li>
+  </ul>
+  <p>
+    We want to inform users of this Service that these third parties have access to your Personal Information.
+    The reason is to perform the tasks assigned to them on our behalf.However, they are obligated not to disclose or use the information for any other purpose.
+  </p>
+  <p><strong>Security</strong></p>
+  <p>
+    We value your trust in providing us your Personal Information, thus we are striving
+    to use commercially acceptable means of protecting it. But remember that no method of transmission
+    over the internet, or method of electronic storage is 100% secure and reliable, and we cannot guarantee its absolute security.
+  </p>
+  <p><strong>Links to Other Sites</strong></p>
+  <p>
+    This Service may contain links to other sites. If you click on a third-party link, you will bedirected
+    to that site. Note that these external sites are not operated by us. Therefore, we strongly advise you to
+    review the Privacy Policy of these websites. We have no control over and assume no responsibility for the content,
+    privacy policies, or practices of any third-party sites or services.
+  </p>
+  <p><strong>Children’s Privacy</strong></p>
+  <p>
+    These Services do not address anyone under the age of 13. We do not knowingly collect personally
+    identifiable information from children under 13. In the case we discover that a child under 13 has provided
+    us with personal information, we immediately delete this from our servers. If you are a parent or guardian and
+    you are aware that your child has provided us with personal information, please contact us so that we will be able to do necessary actions.
+  </p>
+  <p><strong>Changes to This Privacy Policy</strong></p>
+  <p>
+    We may update our Privacy Policy from time to time. Thus, you are advised to review this page periodically
+    for any changes. We will notify you of any changes by posting the new Privacy Policy on this page.
+    These changes are effective immediately after they are posted on this page.
+  </p>
+  <p><strong>Contact Us</strong></p>
+  <p>If you have any questions or suggestions about our Privacy Policy, do not hesitate to contact us at admin@saf-unite.org.</p>
+
+</div>

--- a/app/views/pages/en_terms_and_conditions.html.erb
+++ b/app/views/pages/en_terms_and_conditions.html.erb
@@ -1,0 +1,59 @@
+<div class="container" id="pages">
+  <h2 class="page-heading">Terms &amp; Conditions</h2>
+
+  <p>By downloading or using the app, these terms will automatically apply to you – you should make sure therefore
+  that you read them carefully before using the app. You’re not allowed to copy, or modify the app, any part of the app,
+  or our trademarks in any way. You’re not allowed to attempt to extract the source code of the app, and you also shouldn’t
+  try to translate the app into other languages, or make derivative versions. Theapp itself, and all the trade marks, copyright,
+  database rights and other intellectual property rights related to it, still belong to Student Action with Farmworkers.</p>
+
+  <p>Student Action with Farmworkers is committed to ensuring that the app is as useful and efficient as possible.
+  For that reason, we reserve the right to make changes to the app or to charge for its services, at any time and for any reason.
+  We will never charge you for the app or its services without making it very clear to you exactly what you’re paying for.</p>
+
+  <p>The Conectate Carolina app stores and processes personal data that you have provided to us, in order to provide our Service.
+  It’s your responsibility to keep your phone and access to the app secure. We therefore recommend that you do not jailbreak or
+  root your phone, which is the process of removing software restrictions and limitations imposed by the official operating system
+  of your device. It could make your phone vulnerable to malware/viruses/malicious programs, compromise your phone’s security
+  features and it could mean that the Conectate Carolina app won’t work properly or at all.</p>
+
+  <p>You should be aware that there are certain things that Student Action with Farmworkers will not take responsibility for.
+  Certain functions of the app will require the app to have an active internet connection. The connection can be Wi-Fi, or
+  provided by your mobile network provider, but Student Action with Farmworkers cannot take responsibility for the app not working
+  at full functionality if you don’t have access to Wi-Fi, and you don’t have any of your data allowance left.</p>
+
+  <p>If you’re using the app outside of an area with Wi-Fi, you should remember that your terms of the agreement with your mobile
+  network provider will still apply. As a result, you may be charged by your mobile provider for the cost of data for the duration
+  of the connection while accessing the app, or other third party charges. In using the app, you’re accepting responsibility for
+  any such charges, including roaming data charges if you use the app outside of your home territory (i.e. region or country)
+  without turning off data roaming. If you are not the bill payer for the device on which you’re using the app, please be aware
+  that we assume that you have received permission from the bill payer for using the app.</p>
+
+  <p>Along the same lines, Student Action with Farmworkers cannot always take responsibility for the way you use the app i.e.
+  You need to make sure that your device stays charged – if it runs out of battery and you can’t turn it on to avail the Service,
+  Student Action with Farmworkers cannot accept responsibility.</p>
+
+  <p>With respect to Student Action with Farmworkers’s responsibility for your use of the app,when you’re using the app,
+  it’s important to bear in mind that although we endeavour to ensure that it is updated and correct at all times, we do
+  rely on third parties to provide information to us so that we can make it available to you. Student Action with Farmworkers
+  accepts no liability for any loss, direct or indirect, you experience as a result of relying wholly on this functionality of the app.</p>
+
+  <p>At some point, we may wish to update the app. The app is currently available on Android & iOS – the requirements for both systems
+  (and for any additional systems we decide to extend the availability of the app to) may change, and you’ll need to download the
+  updates if you want to keep using the app. Student Action with Farmworkers does not promise that it will always update the app so
+  that it is relevant to you and/or works with the Android & iOS version that you have installed on your device. However, you promise
+  to always accept updates to the application when offered to you, We may also wish to stop providing the app, and may terminate use
+  of it at any time without giving notice of termination to you. Unless we tell you otherwise, upon any termination, (a) the rights
+  and licenses granted to you in these terms will end; (b) you must stop using the app, and (if needed) delete it from your device.</p>
+
+  <p><strong>Changes to This Terms and Conditions</strong></p>
+
+  <p>We may update our Terms and Conditions from time to time. Thus, you are advised to review this page periodically for any changes.
+  We will notify you of any changes by posting the new Terms and Conditions on this page. These changes are effective immediately
+  after they are posted on this page.</p>
+
+  <p><strong>Contact Us</strong></p>
+
+  <p>If you have any questions or suggestions about our Terms and Conditions, do not hesitate to contact us at admin@saf-unite.org.</p>
+
+</div>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,107 +1,58 @@
 <div class="container" id="pages">
-  <h2 class="page-heading">Privacy Policy</h2>
-  <p>
-    Student Action with Farmworkers built the Conectate Carolina app as a Free app.
-    This SERVICE is provided by Student Action with Farmworkers at no cost and is intended for use as is.
-  </p>
-  <p>
-    This page is used to inform visitors regarding our policies with the collection, use,
-    and disclosure of Personal Information if anyone decided to use our Service.
-  </p>
-  <p>
-    If you choose to use our Service, then you agree to the collection and use of informationin relation to this policy.
-     The Personal Information that we collect is used for providing and improving the Service.
-     We will not use or share your information with anyone except as described in this Privacy Policy.
-  </p>
-  <p>
-    The terms used in this Privacy Policy have the same meanings as in our Terms and Conditions,
-    which is accessible at Conectate Carolina unless otherwise defined in this Privacy Policy.
-  </p>
-  <p><strong>Information Collection and Use</strong></p>
-  <p>
-    For a better experience, while using our Service, we may require you to provide us with certain personally identifiable
-    information, including but not limited to your location as identified by your GPS provider, wifi connection, and/or cellular towers.
-  </p>
-  <p>
-    The information that we request will be retained by us and used as described in this privacy policy.
-  </p>
-  <p>
-    The app does use third party services that may collect information used to identify you.
-  </p>
-  <div>
-    <p>
-      Link to privacy policy of third party service providers used by the app:
-    </p>
-      <ul>
-        <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
-      </ul>
-      </div><p><strong>Log Data</strong></p>
-      <p>
-        We want to inform you that whenever
-        you use our Service, in a case of an error in the
-        app we collect data and information (through third
-        party products) on your phone called Log Data. This Log Data
-        may include information such as your device Internet
-        Protocol (“IP”) address, device name, operating system
-        version, the configuration of the app when utilizing
-        our Service, the time and date of your use of the
-        Service, and other statistics.
-      </p>
-  <p><strong>Cookies</strong></p>
-  <p>
-    Cookies are files with a small amount of data that are
-    commonly used as anonymous unique identifiers. These are sent to your
-    browser from the websites that you visit and are stored on your device's internal memory.
-  </p>
-  <p>
-    This Service does not use these “cookies” explicitly. However, the app may
-    use third party code and libraries that use “cookies” to collect information and
-    improve their services. You have the option to either accept or refuse these cookies
-    and know when a cookie is being sent to your device. If you choose to refuse our cookies,
-    you may not be able to use some portions of this Service.
-  </p>
-  <p><strong>Service Providers</strong></p>
-  <p>
-    We may employ third-party companies
-    and individuals due to the following reasons:
-  </p>
-  <ul>
-    <li>To facilitate our Service;</li>
-    <li>To provide the Service on our behalf;</li>
-    <li>To perform Service-related services; or</li>
-    <li>To assist us in analyzing how our Service is used.</li>
-  </ul>
-  <p>
-    We want to inform users of this Service that these third parties have access to your Personal Information.
-    The reason is to perform the tasks assigned to them on our behalf.However, they are obligated not to disclose or use the information for any other purpose.
-  </p>
-  <p><strong>Security</strong></p>
-  <p>
-    We value your trust in providing us your Personal Information, thus we are striving
-    to use commercially acceptable means of protecting it. But remember that no method of transmission
-    over the internet, or method of electronic storage is 100% secure and reliable, and we cannot guarantee its absolute security.
-  </p>
-  <p><strong>Links to Other Sites</strong></p>
-  <p>
-    This Service may contain links to other sites. If you click on a third-party link, you will bedirected
-    to that site. Note that these external sites are not operated by us. Therefore, we strongly advise you to
-    review the Privacy Policy of these websites. We have no control over and assume no responsibility for the content,
-    privacy policies, or practices of any third-party sites or services.
-  </p>
-  <p><strong>Children’s Privacy</strong></p>
-  <p>
-    These Services do not address anyone under the age of 13. We do not knowingly collect personally
-    identifiable information from children under 13. In the case we discover that a child under 13 has provided
-    us with personal information, we immediately delete this from our servers. If you are a parent or guardian and
-    you are aware that your child has provided us with personal information, please contact us so that we will be able to do necessary actions.
-  </p>
-  <p><strong>Changes to This Privacy Policy</strong></p>
-  <p>
-    We may update our Privacy Policy from time to time. Thus, you are advised to review this page periodically
-    for any changes. We will notify you of any changes by posting the new Privacy Policy on this page.
-    These changes are effective immediately after they are posted on this page.
-  </p>
-  <p><strong>Contact Us</strong></p>
-  <p>If you have any questions or suggestions about our Privacy Policy, do not hesitate to contact us at admin@saf-unite.org.</p>
+  <h2 class="page-heading">Póliza de Privacidad</h2>
+  <p>Estudiantes en Acción con Campesinos (SAF) desarrolló Conéctate Carolina, una aplicación móvil gratuita. Este SERVICIO es proporcionado por Estudiantes en Acción con Campesinos en forma gratuita con la intención de ser utilizado de ese modo.</p>
 
+  <p>Está página se utiliza para informar a los visitantes sobre nuestra póliza de recopilación, uso, y divulgación de Información Personal para los que decidan utilizar nuestro Servicio.</p>
+
+  <p>Si usted elige utilizar nuestro Servicio, usted está de acuerdo en que recopilemos y usemos la información según esta póliza. La Información Personal que recopilamos se utiliza para proporcionar y mejorar el Servicio. No utilizaremos o compartiremos su información con nadie, excepto por lo descrito en esta Póliza de Privacidad.</p>
+
+  <p>Los términos en esta Póliza de Privacidad tienen el mismo significado que en nuestros Términos y Condiciones, los cuales se pueden encontrar en Conéctate Carolina, a menos que se definan de otro modo en esta Póliza de Privacidad.</p>
+
+  <p><strong>Recopilación y Uso de Información</strong></p>
+  <p>Para tener una buena experiencia, mientras utilice nuestro Servicio, puede que requiramos que usted proporcione cierta información personal identificable, lo cual incluye, pero no se limita a su ubicación como sea identificada por su proveedor de GPS (sistema de posicionamiento global), su conexión wifi, y/o sus torres celulares.</p>
+
+  <p>La información que solicitemos será conservada por nosotros y utilizada como se describe en esta Póliza de Privacidad.</p>
+
+  <p>La aplicación utiliza servicios de terceros que pueden recopilar información utilizada para identificarlo a usted.</p>
+
+  <div>
+    <p>Enlace a la Póliza de Privacidad de empresas externas utilizadas por la aplicación:</p>
+    <ul>
+      <li><a href="https://www.google.com/policies/privacy/" target="_blank">Google Play Services</a></li>
+    </ul>
+  </div>
+
+  <p><strong>Datos de registro</strong></p>
+  <p>Queremos informarle que al usar nuestro Servicio, si hay un error en el funcionamiento de la aplicación, recopilamos datos e información (a través de terceros) en su teléfono, lo cual se le llama datos de registro. Estos datos de registro pueden incluir información como el Protocolo de Internet (IP), nombre de su móvil, versión de su sistema operativo, la configuración de la aplicación cuando utilice nuestro Servicio, la hora y fecha cuando usó el Servicio, y otras estadísticas.</p>
+
+  <p><strong>Cookies</strong></p>
+  <p>Los “cookies” son archivos con unos pocos datos que comúnmente se usan como identificador singular anónimo. Estos son enviados a su navegador por sitios web que usted visite y son guardados en la memoria interna de su móvil.</p>
+
+  <p>Este Servicio no utiliza estas “cookies” deliberadamente. Sin embargo, es posible que la aplicación use código de terceros y colecciones que usan “cookies” para recopilar información y mejorar sus servicios. Usted tiene la opción de aceptar o rechazar estas “cookies” y saber cuándo una de estas es enviada a su móvil. Si elige rechazar nuestras “cookies,” es posible que usted no pueda usar algunas partes de este Servicio.</p>
+
+  <p><strong>Proveedores de servicios</strong></p>
+  <p>Es posible que utilicemos empresas e individuos externos debido a las siguientes razones:</p>
+  <ul>
+    <li>Para facilitar nuestro Servicio;</li>
+    <li>Para ofrecer el Servicio de parte nuestra;</li>
+    <li>Para ofrecer actividades relacionadas con nuestro Servicio; o</li>
+    <li>Para ayudarnos a analizar cómo se utiliza nuestro Servicio.</li>
+  </ul>
+
+  <p>Queremos informar a los usuarios de este Servicio que estas empresas externas tienen acceso a su Información Personal, lo cual es para realizar las tareas que les son designadas por parte nuestra. Sin embargo, se les requiere que no revelen o usen la información para cualquier otra razón.</p>
+
+  <p><strong>Seguridad</strong></p>
+  <p>Valoramos su confianza en proporcionarnos su Información Personal, por lo tanto nos esforzamos por usar medios comerciales aceptables para protegerla. Pero recuerde que ningún método de transmisión a través de internet, o de almacenaje electrónico es 100% seguro y fiable, y no podemos garantizar su seguridad absoluta.</p>
+
+  <p><strong>Enlaces a otros sitios</strong></p>
+  <p>Este Servicio puede contener enlaces a otros sitios. Si usted oprime un enlace de una empresa externa, será dirigido a ese sitio. Tome en cuenta que nosotros no manejamos esos sitios externos. Por lo tanto, le recomendamos encarecidamente que lea las Pólizas de Privacidad de esos sitios web. No tenemos control y no asumimos la responsabilidad por el contenido, pólizas de privacidad, o prácticas de cualquier sitio web o servicios de terceros.</p>
+
+  <p><strong>Privacidad de menores</strong></p>
+  <p>Estos Servicios no son dirigidos a ninguna persona que tenga menos de trece años de edad. No recopilamos información personal identificable intencionalmente de niñas/os menores de 13 años. En caso de descubrir que un/a niño/a menor de 13 años haya proporcionado su información personal, la borramos inmediatamente de nuestros servidores. Si usted es un padre/madre o tutor y sabe que su hijo/a nos ha proporcionado su información personal, por favor comuníquese con nosotros para tomar las acciones necesarias.</p>
+
+  <p><strong>Cambios a esta Póliza de Privacidad</strong></p>
+  <p>De vez en cuando es posible que actualicemos nuestra Póliza de Privacidad. De ese modo, le recomendamos que revise esta página regularmente para enterarse de cualquier cambio. Le avisaremos de cualquier cambio al publicar la nueva Póliza de Privacidad en esta página. Estos cambios tienen efecto inmediatamente después de ser publicados en esta página.</p>
+
+  <p><strong>Comuníquese con nosotros</strong></p>
+  <p>Si tiene cualquier pregunta o sugerencia sobre nuestra Póliza de Privacidad, no dude en comunicarse con nosotros al escribir a admin@saf-unite.org.</p>
 </div>

--- a/app/views/pages/terms_and_conditions.html.erb
+++ b/app/views/pages/terms_and_conditions.html.erb
@@ -1,59 +1,25 @@
 <div class="container" id="pages">
-  <h2 class="page-heading">Terms &amp; Conditions</h2>
+  <h2 class="page-heading">Términos y Condiciones</h2>
 
-  <p>By downloading or using the app, these terms will automatically apply to you – you should make sure therefore
-  that you read them carefully before using the app. You’re not allowed to copy, or modify the app, any part of the app,
-  or our trademarks in any way. You’re not allowed to attempt to extract the source code of the app, and you also shouldn’t
-  try to translate the app into other languages, or make derivative versions. Theapp itself, and all the trade marks, copyright,
-  database rights and other intellectual property rights related to it, still belong to Student Action with Farmworkers.</p>
+  <p>Al descargar o utilizar la aplicación, estos términos automáticamente le afectarán a usted – por eso, debe asegurarse de leerlos detenidamente antes de utilizar la aplicación. No se permite que copie o modifique la aplicación, cualquier parte de la aplicación, o nuestras marcas registradas de una forma u otra. No se permite que trate de obtener el código fuente de la aplicación, y tampoco debe tratar de traducir la aplicación a otros idiomas, o crear versiones derivadas. La aplicación en sí, y todas las marcas registradas, derechos de autor, derechos de base de datos, y otros derechos de propiedad intelectual relacionadas, aún le pertenecen a Estudiantes en Acción con Campesinos (SAF).</p>
 
-  <p>Student Action with Farmworkers is committed to ensuring that the app is as useful and efficient as possible.
-  For that reason, we reserve the right to make changes to the app or to charge for its services, at any time and for any reason.
-  We will never charge you for the app or its services without making it very clear to you exactly what you’re paying for.</p>
+  <p>Estudiantes en Acción con Campesinos (SAF) se compromete a asegurar que la aplicación sea lo más útil y eficiente posible. Por esa razón, se reserva el derecho a hacer cambios a la aplicación o cobrar por los servicios, en cualquier momento y por cualquier razón. Nunca le cobraremos por la aplicación o sus servicios sin dejarle en claro exactamente por lo que está pagando.</p>
 
-  <p>The Conectate Carolina app stores and processes personal data that you have provided to us, in order to provide our Service.
-  It’s your responsibility to keep your phone and access to the app secure. We therefore recommend that you do not jailbreak or
-  root your phone, which is the process of removing software restrictions and limitations imposed by the official operating system
-  of your device. It could make your phone vulnerable to malware/viruses/malicious programs, compromise your phone’s security
-  features and it could mean that the Conectate Carolina app won’t work properly or at all.</p>
+  <p>La aplicación Conéctate Carolina guarda y procesa datos personales que usted nos ha proporcionado con el fin de ofrecer nuestro Servicio. Es su responsabilidad cuidar su teléfono y evitar que otros tengan acceso a la aplicación. Por lo tanto recomendamos que no haga jailbreak o root a su teléfono, lo cual es el proceso de quitar restricciones de software y limites colocados por el sistema de operación oficial de su móvil. Esto podría hacer que su móvil sea vulnerable a malware/virus/programas malignos, que se pongan en riesgo las medidas de seguridad de su teléfono, y que la aplicación de Conéctate Carolina no funcione adecuadamente o en absoluto.</p>
 
-  <p>You should be aware that there are certain things that Student Action with Farmworkers will not take responsibility for.
-  Certain functions of the app will require the app to have an active internet connection. The connection can be Wi-Fi, or
-  provided by your mobile network provider, but Student Action with Farmworkers cannot take responsibility for the app not working
-  at full functionality if you don’t have access to Wi-Fi, and you don’t have any of your data allowance left.</p>
+  <p>Usted debe estar informado que hay ciertas cosas por las cuales Estudiantes en Acción con Campesinos (SAF) no se hará responsable. Ciertas funciones de la aplicación requieren que tenga una conexión a internet en funcionamiento. La conexión puede ser de wifi, o de su proveedor de red de telefonía móvil, pero Estudiantes en Acción con Campesinos (SAF) no puede hacerse responsable si no todas las características de la aplicación funcionan por no tener acceso a wifi, o si excede su límite de datos.</p>
 
-  <p>If you’re using the app outside of an area with Wi-Fi, you should remember that your terms of the agreement with your mobile
-  network provider will still apply. As a result, you may be charged by your mobile provider for the cost of data for the duration
-  of the connection while accessing the app, or other third party charges. In using the app, you’re accepting responsibility for
-  any such charges, including roaming data charges if you use the app outside of your home territory (i.e. region or country)
-  without turning off data roaming. If you are not the bill payer for the device on which you’re using the app, please be aware
-  that we assume that you have received permission from the bill payer for using the app.</p>
+  <p>Si está usando la aplicación fuera de una zona con wifi, debe recordar que los términos del acuerdo con su proveedor de red de telefonía móvil siguen siendo validos. Como resultado, es posible que su proveedor de telefonía le cobre por el costo de datos mientras esté conectado y utilice la aplicación, u otros cargos de terceros. Al usar la aplicación, usted acepta responsabilidad por cualquier cargo, incluyendo cargos por servicio de roaming si utiliza la aplicación fuera de su zona (esto es, región o país) sin apagar el servicio de roaming. Si usted no es la persona que paga el móvil que utilice para entrar a la aplicación, por favor tenga en cuenta que supondremos que usted recibió permiso del pagador para usar la aplicación.</p>
 
-  <p>Along the same lines, Student Action with Farmworkers cannot always take responsibility for the way you use the app i.e.
-  You need to make sure that your device stays charged – if it runs out of battery and you can’t turn it on to avail the Service,
-  Student Action with Farmworkers cannot accept responsibility.</p>
+  <p>De la misma forma, Estudiantes en Acción con Campesinos (SAF) no siempre puede hacerse responsable por la manera en la que usted utilice la aplicación. Esto es, usted debe asegurarse de cargar su móvil – si se queda sin batería y no lo puede encender para utilizar el Servicio, Estudiantes en Acción con Campesinos (SAF) no se puede hacer responsable.</p>
 
-  <p>With respect to Student Action with Farmworkers’s responsibility for your use of the app,when you’re using the app,
-  it’s important to bear in mind that although we endeavour to ensure that it is updated and correct at all times, we do
-  rely on third parties to provide information to us so that we can make it available to you. Student Action with Farmworkers
-  accepts no liability for any loss, direct or indirect, you experience as a result of relying wholly on this functionality of the app.</p>
+  <p>Con respeto a la responsabilidad de Estudiantes en Acción con Campesinos (SAF) por su uso de la aplicación, es importante tener en cuenta que aunque nos esforzamos por asegurarnos de que siempre esté actualizada y la información sea correcta, nosotros dependemos de empresas externas para proporcionarnos datos para hacerlos disponibles a usted. Estudiantes en Acción con Campesinos (SAF) no acepta responsabilidad por cualquier pérdida, directa o indirecta, que usted sufra como resultado de depender totalmente en la funcionalidad de la aplicación.</p>
 
-  <p>At some point, we may wish to update the app. The app is currently available on Android & iOS – the requirements for both systems
-  (and for any additional systems we decide to extend the availability of the app to) may change, and you’ll need to download the
-  updates if you want to keep using the app. Student Action with Farmworkers does not promise that it will always update the app so
-  that it is relevant to you and/or works with the Android & iOS version that you have installed on your device. However, you promise
-  to always accept updates to the application when offered to you, We may also wish to stop providing the app, and may terminate use
-  of it at any time without giving notice of termination to you. Unless we tell you otherwise, upon any termination, (a) the rights
-  and licenses granted to you in these terms will end; (b) you must stop using the app, and (if needed) delete it from your device.</p>
+  <p>En algún momento, es posible que actualicemos la aplicación. La aplicación actualmente está disponible en Android e iOS – los requisitos de ambos sistemas (y de cualquier sistema adicional que decidamos añadir) puede cambiar, y usted deberá descargar las actualizaciones si desea seguir usando la aplicación. Estudiantes en Acción con Campesinos (SAF) no se puede comprometer a siempre actualizar la aplicación para que sea relevante para usted y/o funcione con las versiones de Android e iOS que haya instalado en su móvil. Sin embargo, usted promete aceptar las actualizaciones a la aplicación cuando estén disponibles. Puede que decidamos dejar de ofrecer la aplicación, y terminemos su uso en cualquier momento sin avisarle de su suspensión. A menos que le avisemos otra cosa, al suspenderse, se terminarán (a) los derechos y licencias concedidas a usted en estos términos; (b) usted debe dejar de usar la aplicación, y (si es necesario) usted debe borrar la aplicación de su móvil.</p>
 
-  <p><strong>Changes to This Terms and Conditions</strong></p>
+  <p><strong>Cambios a los Términos y Condiciones</strong></p>
+  <p>De vez en cuando es posible que actualicemos nuestros Términos y Condiciones. De ese modo, le recomendamos que revise esta página regularmente para enterarse de cualquier cambio. Le avisaremos de cualquier cambio al publicar los nuevos Términos y Condiciones en esta página. Estos cambios tienen efecto inmediato después de ser publicados en esta página.</p>
 
-  <p>We may update our Terms and Conditions from time to time. Thus, you are advised to review this page periodically for any changes.
-  We will notify you of any changes by posting the new Terms and Conditions on this page. These changes are effective immediately
-  after they are posted on this page.</p>
-
-  <p><strong>Contact Us</strong></p>
-
-  <p>If you have any questions or suggestions about our Terms and Conditions, do not hesitate to contact us at admin@saf-unite.org.</p>
-
+  <p><strong>Comuníquese con nosotros</strong></p>
+  <p>Si tiene cualquier pregunta o sugerencia sobre nuestros Términos y Condiciones, no dude en comunicarse con nosotros al escribir a admin@saf-unite.org.</p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,9 @@ en:
     sign_up: Sign up
     edit_accnt: Edit Account
     sign_out: Sign out
+  pages:
+    privacy: Privacy Policy
+    tac: Terms & Conditions
   category:
     categories: Categories
     all_cat: List of Categories

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -29,6 +29,9 @@ es:
     sign_up: Inscribirse
     edit_accnt: Actualizar cuenta
     sign_out: Terminar sesion
+  pages:
+    privacy: Póliza de Privacidad
+    tac: Términos y Condiciones
   category:
     categories: Categorías
     all_cat: Lista de Categorias

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,9 @@ Rails.application.routes.draw do
 		resources :faqs
 		get 'about', to: 'pages#about'
     get 'pages/privacy_policy'
+    get 'pages/en_privacy_policy'
     get 'pages/terms_and_conditions'
+    get 'pages/en_terms_and_conditions'
     get 'mobile', to: 'pages#mobile_page'
 	  get 'search', to: 'search#search'
     resources :categories


### PR DESCRIPTION
- Added spanish translations of `Privacy Policy` and `Terms and Conditions` documents
- Ran rspec to make sure everything is working fine after the change.
@jrmcgarvey @micronix 

Thanks!