### PR TITLE
Spanish month on alert details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'bootstrap-sass'
 gem 'devise'
 gem 'devise-i18n'
+gem 'rails-i18n'
 gem 'high_voltage'
 gem 'pundit'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -381,6 +384,7 @@ DEPENDENCIES
   pundit
   rails
   rails-controller-testing
+  rails-i18n
   rails_12factor
   rails_layout
   rb-readline

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -120,14 +120,6 @@
 	color: #f44336;
 }
 
-span.time-stamp {
-	font-style: italic;
-}
-
-p.time-stamp {
-	font-style: italic;
-}
-
 p.message-body a {
 	color: #2875b6;
 	font-size: inherit;

--- a/app/views/agencies/show.html.erb
+++ b/app/views/agencies/show.html.erb
@@ -8,7 +8,7 @@
 <div class="row row-centered padding-resize">
 <div class="col-centered">
   <div class="panel panel-success">
-    <div class="panel-body padding-resize">
+    <div class="panel-body padding-resize" style="padding-top: 40px;">
       <div class="col-md-6 col-sm-6 padding-resize">
         <div class="well well-sm well-agency">
           <p class="lead agency-name">

--- a/app/views/user_messages/index.html.erb
+++ b/app/views/user_messages/index.html.erb
@@ -37,7 +37,7 @@
             <p>
               <b><%= user_message.title if locale == :en %></b>
               <b><%= user_message.titulo if locale == :es %></b><br>
-              <span class="time-stamp"><%= distance_of_time_in_words(user_message.posted_at, Time.now)%></span>
+              <span class="time-stamp"><%= distance_of_time_in_words(user_message.posted_at, Time.now)%> ago</span>
             </p>
           </div>
         </div>

--- a/app/views/user_messages/show.html.erb
+++ b/app/views/user_messages/show.html.erb
@@ -2,9 +2,29 @@
   <div class="row">
     <div class="panel panel-default">
       <div class="panel-body">
-        <p><b><%= @user_message.title%></b><br/>
-        <span class="time-stamp"><%= @user_message.posted_at.strftime("%b %d, %Y %I:%M %p")%></span></p>
-        <p class="message-body"><%= auto_link(@user_message.body, html: {target: '_blank'}) %></p>
+        <% if locale == :en %>
+          <p><b><%= @user_message.title%></b><br/>
+          <%= @user_message.posted_at.strftime('%b %d, %I:%M %p') %></p>
+          <p class="message-body"><%= auto_link(@user_message.body, html: {target: '_blank'}) %></p>
+
+        <% elsif locale == :es %>
+          <% @month_short_name = @user_message.posted_at.strftime('%b')
+             @second_part      = @user_message.posted_at.strftime('%d, %I:%M %p') %>
+          <p><b><%= @user_message.titulo%></b><br/>
+          <% case @month_short_name %>
+          <% when 'Jan' %>
+            ene <%= @second_part %></p>
+          <% when 'Apr' %>
+            abr <%= @second_part %></p>
+          <% when 'Aug' %>
+            ago <%= @second_part %></p>
+          <% when 'Dec' %>
+            dic <%= @second_part %></p>
+          <% else %>
+            <%= @user_message.posted_at.strftime('%b').downcase %> <%= @second_part %></p>
+          <% end %>
+          <p class="message-body"><%= auto_link(@user_message.cuerpo, html: {target: '_blank'}) %></p>
+        <% end %>
       </div>
     </div>
     <div class="panel panel-default">

--- a/app/views/user_messages/show.html.erb
+++ b/app/views/user_messages/show.html.erb
@@ -8,22 +8,10 @@
           <p class="message-body"><%= auto_link(@user_message.body, html: {target: '_blank'}) %></p>
 
         <% elsif locale == :es %>
-          <% @month_short_name = @user_message.posted_at.strftime('%b')
-             @second_part      = @user_message.posted_at.strftime('%d, %I:%M %p') %>
           <p><b><%= @user_message.titulo%></b><br/>
-          <% case @month_short_name %>
-          <% when 'Jan' %>
-            ene <%= @second_part %></p>
-          <% when 'Apr' %>
-            abr <%= @second_part %></p>
-          <% when 'Aug' %>
-            ago <%= @second_part %></p>
-          <% when 'Dec' %>
-            dic <%= @second_part %></p>
-          <% else %>
-            <%= @user_message.posted_at.strftime('%b').downcase %> <%= @second_part %></p>
-          <% end %>
+          <%= I18n.l(@user_message.posted_at, format: '%b %d, %I:%M %p', locale: 'es-US') %></p>
           <p class="message-body"><%= auto_link(@user_message.cuerpo, html: {target: '_blank'}) %></p>
+
         <% end %>
       </div>
     </div>

--- a/app/views/user_messages/show.html.erb
+++ b/app/views/user_messages/show.html.erb
@@ -1,6 +1,14 @@
-<div class="jumbotron" id="jumbotron">
-  <p><strong><%= @user_message.title%></strong><br>
-  <span class="time-stamp"><%= @user_message.posted_at.strftime("%b %d, %Y %I:%M %p")%></span></p>
-  <p class="message-body"><%= auto_link(@user_message.body, html: {target: '_blank'}) %></p>
-  <%= link_to "Back", user_messages_path, class: "btn btn-info"  %>
+<div class="containers">
+  <div class="row">
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <p><b><%= @user_message.title%></b><br/>
+        <span class="time-stamp"><%= @user_message.posted_at.strftime("%b %d, %Y %I:%M %p")%></span></p>
+        <p class="message-body"><%= auto_link(@user_message.body, html: {target: '_blank'}) %></p>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <%= link_to "Back", user_messages_path, class: "btn btn-success"  %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
- Made `alert` details page mobile responsive 
- Made `spanish` months appear on the alert details page's timestamp
- Added space for header in organization's details page

@jrmcgarvey 
Thank you!