### PR TITLE
Add statewide agency search on webapp

### DIFF
--- a/app/views/agencies/index.html.erb
+++ b/app/views/agencies/index.html.erb
@@ -88,9 +88,9 @@ getLocation();
           <div class="col-md-2">
             <!-- <%= label :distance, "Choose a distance : " %> -->
             <% if params[:locale] == "en" %>
-              <%= select_tag :distance, options_for_select([['10 Miles', 10], ['30 Miles', 30], ['All', 12000]]), class: "form-control" %>
+              <%= select_tag :distance, options_for_select([['10 Miles', 10], ['30 Miles', 30], ['50 Miles', 50], ['100 Miles', 100], ['Anywhere', 12000]]), class: "form-control" %>
             <% else %>
-              <%= select_tag :distance, options_for_select([['10 Millas', 10], ['30 Millas', 30], ['Todas', 12000]]), class: "form-control" %>
+              <%= select_tag :distance, options_for_select([['10 Millas', 10], ['30 Millas', 30], ['50 Millas', 50], ['100 Millas', 100], ['En cualquier lugar', 12000]]), class: "form-control" %>
             <% end %>
           </div>
 

--- a/app/views/agencies/index.html.erb
+++ b/app/views/agencies/index.html.erb
@@ -85,12 +85,12 @@ getLocation();
             <!-- <%= text_field_tag :location, params[:location], placeholder: "search by location", :class => 'form-control search-input', autofocus: params[:location].present? %> -->
 
           </div>
-          <div class="col-md-1">
+          <div class="col-md-2">
             <!-- <%= label :distance, "Choose a distance : " %> -->
             <% if params[:locale] == "en" %>
-              <%= select_tag :distance, options_for_select([['10 Miles', 10], ['30 Miles', 30], ['50 Miles', 50]]), class: "form-control" %>
+              <%= select_tag :distance, options_for_select([['10 Miles', 10], ['30 Miles', 30], ['All', 12000]]), class: "form-control" %>
             <% else %>
-              <%= select_tag :distance, options_for_select([['10 Millas', 10], ['30 Millas', 30], ['50 Millas', 50]]), class: "form-control" %>
+              <%= select_tag :distance, options_for_select([['10 Millas', 10], ['30 Millas', 30], ['Todas', 12000]]), class: "form-control" %>
             <% end %>
           </div>
 


### PR DESCRIPTION
- Added `statewide` agency search on Web app by adding `All`(`Todas` in spanish) in the dropdown for distance that fetches `agencies` within `12000` miles

Thanks @micronix !!

<img width="1359" alt="Screen Shot 2021-05-25 at 3 11 20 PM" src="https://user-images.githubusercontent.com/25111094/119555931-65fb0780-bd6c-11eb-946e-21c591b340c5.png">

<img width="1363" alt="Screen Shot 2021-05-25 at 3 12 34 PM" src="https://user-images.githubusercontent.com/25111094/119555954-6d221580-bd6c-11eb-8b58-545cd09092f7.png">
