### PR TITLE
Display nombre when in spanish and county in both english and spanish

### DIFF
--- a/app/views/agencies/_section3.html.erb
+++ b/app/views/agencies/_section3.html.erb
@@ -50,8 +50,15 @@
             </span>
           </a>
         </address>
-        <% no_info = params[:locale] == 'en' ? 'No info' : 'Nada' %>
-        <p><%= t'show_page.county' %> <small><%= agency.county ? agency.county : no_info %></small></p>
+        <p><%= t'show_page.county' %>
+          <small>
+            <% if agency.county.present? %>
+              <%= agency.county %>
+            <%else%>
+             <%=t'show_page.no_info'%>
+             <%end%>
+          </small>
+        </p>
 
           <!-- check HTML in this agency card   -->
           <p><%= Agency.human_attribute_name("contact") %><br>

--- a/app/views/agencies/_section3.html.erb
+++ b/app/views/agencies/_section3.html.erb
@@ -31,15 +31,17 @@
         <div class="card_title">
           <p class="lead agency-name">
             <strong>
-              <%= link_to agency.name, controller: 'agencies',
-              action: 'show', id: agency.id%>
+              <% if params[:locale] == 'en' %>
+                <%= link_to agency.name, controller: 'agencies', action: 'show', id: agency.id%>
+              <% else %>
+                <%= link_to agency.nombre, controller: 'agencies', action: 'show', id: agency.id%>
+              <% end %>
             </strong>
           </p>
-
         </div>
         <div>
         <hr>
-        <p><%=(t'show_page.address') %><br></p>
+        <p><%=(t'show_page.address') %></p>
         <address>
           <%= agency.full_address %>
           <a href="https://www.google.com/maps/dir/Current+Location/<%= agency.full_address %>" class="btn btn-default btn-sm btn-link" target="_blank">
@@ -48,6 +50,8 @@
             </span>
           </a>
         </address>
+        <p><%= t'show_page.county' %> <small><%= agency.county ? agency.county : 'No info' %></small></p>
+
           <!-- check HTML in this agency card   -->
           <p><%= Agency.human_attribute_name("contact") %><br>
             <div id="agency-attributes">

--- a/app/views/agencies/_section3.html.erb
+++ b/app/views/agencies/_section3.html.erb
@@ -50,7 +50,8 @@
             </span>
           </a>
         </address>
-        <p><%= t'show_page.county' %> <small><%= agency.county ? agency.county : 'No info' %></small></p>
+        <% no_info = params[:locale] == 'en' ? 'No info' : 'Nada' %>
+        <p><%= t'show_page.county' %> <small><%= agency.county ? agency.county : no_info %></small></p>
 
           <!-- check HTML in this agency card   -->
           <p><%= Agency.human_attribute_name("contact") %><br>

--- a/app/views/agencies/show.html.erb
+++ b/app/views/agencies/show.html.erb
@@ -12,7 +12,11 @@
       <div class="col-md-6 col-sm-6 padding-resize">
         <div class="well well-sm well-agency">
           <p class="lead agency-name">
-            <strong><%= link_to @agency.name, @agency %></strong>
+            <% if params[:locale] == 'en' %>
+              <strong><%= link_to @agency.name, @agency %></strong>
+            <% else %>
+              <strong><%= link_to @agency.nombre, @agency %></strong>
+            <% end %>
           </p>
           <hr>
           <p><b><%=(t'show_page.address') %></b>
@@ -22,6 +26,7 @@
                 <i class="fa fa-map-marker fa-2x"></i>
               </span>
             </a></p>
+          <p><b><%= (t'show_page.county') %></b> <%= @agency.county ? @agency.county : 'No info'%></p>
           <p><b><%= (t'show_page.contact') %></b>
             <%= @agency.contact %>
             <a href="mailto:<%= @agency.email %>" class="btn btn-default btn-sm btn-link">

--- a/app/views/agencies/show.html.erb
+++ b/app/views/agencies/show.html.erb
@@ -26,7 +26,13 @@
                 <i class="fa fa-map-marker fa-2x"></i>
               </span>
             </a></p>
-          <p><b><%= (t'show_page.county') %></b> <%= @agency.county ? @agency.county : 'No info'%></p>
+          <p><b><%= (t'show_page.county') %></b>
+            <% if @agency.county.present? %>
+              <%= @agency.county %>
+            <%else%>
+             <%=t'show_page.no_info'%>
+             <%end%>
+          </p>
           <p><b><%= (t'show_page.contact') %></b>
             <%= @agency.contact %>
             <a href="mailto:<%= @agency.email %>" class="btn btn-default btn-sm btn-link">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
     description: "Description:"
     websites: "Websites"
     title: "Title:"
+    no_info: "No info"
   buttons_t:
     back: Back
     edit: Edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,7 @@ en:
     state: "State:"
     city: "City:"
     zip: "Zip code:"
+    county: "County:"
     contact: "Contact:"
     phone: "Phone Numbers:"
     description: "Description:"
@@ -198,6 +199,7 @@ en:
     city: Raleigh
     state: Ex. NC
     zipcode: "27516"
+    county: Wake
   footer:
     about: About
     organizations: Organizations

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -157,6 +157,7 @@ es:
     state: 'Estado:'
     city: 'Ciudad:'
     zip: 'Codigo postal:'
+    county: 'Condado:'
     contact: 'Contacto:'
     phone: 'Numeros De telefono:'
     description: 'Descripcion:'
@@ -174,6 +175,7 @@ es:
     city: Raleigh
     state: Ej. NC
     zipcode: '27516'
+    county: Wake
   footer:
     about: Acerca
     organizations: Organizaciones

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -163,6 +163,7 @@ es:
     description: 'Descripcion:'
     websites: 'Sitios web'
     title: 'Titulo:'
+    no_info: "Nada"
   buttons_t:
     back: Atras
     edit: Actualizar


### PR DESCRIPTION
- Displayed `nombre` instead of `name` for agencies when in `spanish`
- Display `county` for both `english` and `spanish` 
Thanks @micronix !

<img width="1381" alt="Screen Shot 2021-06-04 at 12 40 38 PM" src="https://user-images.githubusercontent.com/25111094/120835812-d0613400-c532-11eb-8366-cafbdb888ccd.png">

<img width="1347" alt="Screen Shot 2021-06-04 at 12 42 39 PM" src="https://user-images.githubusercontent.com/25111094/120835839-d820d880-c532-11eb-83fd-76aa5d032ea7.png">
