### PR TITLE
Create device_messages table to track messages sent to a device/cc-34

### DIFF
--- a/app/models/device_message.rb
+++ b/app/models/device_message.rb
@@ -1,0 +1,4 @@
+class DeviceMessage < ApplicationRecord
+  belongs_to :device
+  belongs_to :message
+end

--- a/db/migrate/20210810200941_create_device_messages.rb
+++ b/db/migrate/20210810200941_create_device_messages.rb
@@ -1,0 +1,13 @@
+class CreateDeviceMessages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :device_messages do |t|
+      t.references :device, null: false, foreign_key: true
+      t.references :message, null: false, foreign_key: true
+      t.string :ticket_id
+      t.string :status
+      t.json :errors
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210810200941_create_device_messages.rb
+++ b/db/migrate/20210810200941_create_device_messages.rb
@@ -5,7 +5,7 @@ class CreateDeviceMessages < ActiveRecord::Migration[6.1]
       t.references :message, null: false, foreign_key: true
       t.string :ticket_id
       t.string :status
-      t.json :errors
+      t.json :error_messages
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,31 +42,6 @@ ActiveRecord::Schema.define(version: 2021_08_10_200941) do
     t.integer "category_id"
   end
 
-  create_table "agency_update_requests", force: :cascade do |t|
-    t.string "name"
-    t.string "nombre"
-    t.string "address"
-    t.string "city"
-    t.string "state"
-    t.string "zipcode"
-    t.string "county"
-    t.float "latitude"
-    t.float "longitude"
-    t.string "contact"
-    t.string "phone"
-    t.string "description"
-    t.string "email"
-    t.string "descripcion"
-    t.string "mobile_phone"
-    t.string "status", default: "submitted"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.bigint "agency_id", null: false
-    t.string "submitted_by", null: false
-    t.string "submitter_email", null: false
-    t.index ["agency_id"], name: "index_agency_update_requests_on_agency_id"
-  end
-
   create_table "categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -80,7 +55,7 @@ ActiveRecord::Schema.define(version: 2021_08_10_200941) do
     t.bigint "message_id", null: false
     t.string "ticket_id"
     t.string "status"
-    t.json "errors"
+    t.json "error_messages"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["device_id"], name: "index_device_messages_on_device_id"
@@ -163,7 +138,6 @@ ActiveRecord::Schema.define(version: 2021_08_10_200941) do
 
   add_foreign_key "agency_categories", "agencies"
   add_foreign_key "agency_categories", "categories"
-  add_foreign_key "agency_update_requests", "agencies"
   add_foreign_key "device_messages", "devices"
   add_foreign_key "device_messages", "messages"
   add_foreign_key "websites", "agencies"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_25_201118) do
+ActiveRecord::Schema.define(version: 2021_08_10_200941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,12 +42,49 @@ ActiveRecord::Schema.define(version: 2021_05_25_201118) do
     t.integer "category_id"
   end
 
+  create_table "agency_update_requests", force: :cascade do |t|
+    t.string "name"
+    t.string "nombre"
+    t.string "address"
+    t.string "city"
+    t.string "state"
+    t.string "zipcode"
+    t.string "county"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "contact"
+    t.string "phone"
+    t.string "description"
+    t.string "email"
+    t.string "descripcion"
+    t.string "mobile_phone"
+    t.string "status", default: "submitted"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "agency_id", null: false
+    t.string "submitted_by", null: false
+    t.string "submitter_email", null: false
+    t.index ["agency_id"], name: "index_agency_update_requests_on_agency_id"
+  end
+
   create_table "categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "categoria"
     t.string "fa_name"
+  end
+
+  create_table "device_messages", force: :cascade do |t|
+    t.bigint "device_id", null: false
+    t.bigint "message_id", null: false
+    t.string "ticket_id"
+    t.string "status"
+    t.json "errors"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["device_id"], name: "index_device_messages_on_device_id"
+    t.index ["message_id"], name: "index_device_messages_on_message_id"
   end
 
   create_table "devices", force: :cascade do |t|
@@ -84,7 +121,7 @@ ActiveRecord::Schema.define(version: 2021_05_25_201118) do
     t.integer "searchable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
@@ -126,6 +163,9 @@ ActiveRecord::Schema.define(version: 2021_05_25_201118) do
 
   add_foreign_key "agency_categories", "agencies"
   add_foreign_key "agency_categories", "categories"
+  add_foreign_key "agency_update_requests", "agencies"
+  add_foreign_key "device_messages", "devices"
+  add_foreign_key "device_messages", "messages"
   add_foreign_key "websites", "agencies"
   add_foreign_key "websites", "website_types"
 end

--- a/spec/factories/device_messages.rb
+++ b/spec/factories/device_messages.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :device_message do
+    device { nil }
+    message { nil }
+    ticket_id { "MyString" }
+    status { "MyString" }
+    errors { "" }
+  end
+end

--- a/spec/models/device_message_spec.rb
+++ b/spec/models/device_message_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DeviceMessage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- Created new `device_messages` table with columns `device_id`, `message_id`, `ticket_id`, `status`, and `errors`.

Thanks @micronix !