### PR TITLE
Add logic to display agency name when nombre is nil in Spanish

### DIFF
--- a/app/controllers/agency_update_requests_controller.rb
+++ b/app/controllers/agency_update_requests_controller.rb
@@ -14,6 +14,9 @@ class AgencyUpdateRequestsController < ApplicationController
 
   def create
     @agency_update_request = @agency.agency_update_requests.new(ag_params)
+    if ag_params[:nombre].blank?
+      @agency_update_request.nombre = nil
+    end
     if @agency_update_request.save
       flash.notice = (t'flash_notice.update-success')
       redirect_to @agency
@@ -45,6 +48,9 @@ class AgencyUpdateRequestsController < ApplicationController
                                                                   :descripcion,
                                                                   :mobile_phone
                                                                   ))
+        if ag_params[:nombre].blank?
+          @agency.update(nombre: nil)
+        end
         flash.notice = (t'flash_notice.approve-success')
         redirect_to agency_path(@agency)
       elsif params["status"] == "rejected"

--- a/app/views/agencies/show.html.erb
+++ b/app/views/agencies/show.html.erb
@@ -15,7 +15,7 @@
             <% if params[:locale] == 'en' %>
               <strong><%= link_to @agency.name, @agency %></strong>
             <% else %>
-              <strong><%= link_to @agency.nombre, @agency %></strong>
+              <strong><%= link_to (@agency.nombre || @agency.name), @agency %></strong>
             <% end %>
           </p>
           <hr>

--- a/app/views/agency_update_requests/index.html.erb
+++ b/app/views/agency_update_requests/index.html.erb
@@ -21,7 +21,7 @@
               <% if params[:locale] == 'en' %>
                 <%= link_to agency.name, controller: 'agency_update_requests', action: 'edit', id: agency.id%>
               <% else %>
-                <%= link_to agency.nombre, controller: 'agency_update_requests', action: 'edit', id: agency.id%>
+                <%= link_to (agency.nombre || agency.name), controller: 'agency_update_requests', action: 'edit', id: agency.id%>
               <% end %>
             </strong>
           </p>


### PR DESCRIPTION
- Added a logic to display `name` where `nombre` is nil
- Fixed `agency update requests` controller to have `nil` value for `nombre` when it is blank
Thank you @micronix 

- Agency update request index page
<img width="1355" alt="Screen Shot 2021-08-25 at 2 47 03 PM" src="https://user-images.githubusercontent.com/25111094/130848559-b23b0858-7892-4a51-9093-7c88d538ebb3.png">


- Agency show page
<img width="1374" alt="Screen Shot 2021-08-25 at 2 49 35 PM" src="https://user-images.githubusercontent.com/25111094/130848655-125aa1c2-6ade-426d-a23b-a64fd56dfc72.png">

