### PR TITLE
nrai/remove btn class for categories on agency form/cc 23

### DIFF
--- a/app/views/agencies/_form.html.erb
+++ b/app/views/agencies/_form.html.erb
@@ -98,19 +98,22 @@
     </div>
   </div>
 
-  <div class="checkbox">
-    <%= f.collection_check_boxes :category_ids, Category.all, :id, :name do |cb| %>
-      <%= cb.label(class: 'checkbox input_checkbox') {
-        cb.check_box(class: 'checkbox') + cb.text }  %>
-    <% end %>
-  </div>
-  <br>
-
-    <div class="panel-inline-body">
-      <%= link_to (t'buttons_t.back'), agencies_path, class: 'btn btn-primary' %>
-      <%= f.button (t'buttons_t.save'), class: "btn btn-primary btn-info",
-        data: {disable_with:
-        "<i class='fa fa-spinner fa-pulse fa-lg fa-fw'></i> Saving..."} %><br>
+  <div class="form-group">
+    <%= f.label "Categories", class: 'control-label col-md-4' %>
+    <div class="controls col-md-8">
+      <div class="checkbox">
+        <%= f.collection_check_boxes :category_ids, Category.all, :id, :name do |cb| %>
+          <%= cb.label(class: 'checkbox input_checkbox') {
+            cb.check_box(class: 'checkbox') + cb.text }  %>
+        <% end %>
+      </div>
     </div>
+  </div>
 
-<% end %> <%# end of form_for %>
+  <div class="panel-inline-body">
+    <%= link_to (t'buttons_t.back'), agencies_path, class: 'btn btn-primary' %>
+    <%= f.button (t'buttons_t.save'), class: "btn btn-primary btn-info",
+      data: {disable_with:
+      "<i class='fa fa-spinner fa-pulse fa-lg fa-fw'></i> Saving..."} %><br>
+  </div>
+<% end %>

--- a/app/views/agencies/_form.html.erb
+++ b/app/views/agencies/_form.html.erb
@@ -100,7 +100,7 @@
 
   <div class="checkbox">
     <%= f.collection_check_boxes :category_ids, Category.all, :id, :name do |cb| %>
-      <%= cb.label(class: 'checkbox input_checkbox btn btn-default') {
+      <%= cb.label(class: 'checkbox input_checkbox') {
         cb.check_box(class: 'checkbox') + cb.text }  %>
     <% end %>
   </div>

--- a/app/views/agencies/edit.html.erb
+++ b/app/views/agencies/edit.html.erb
@@ -1,14 +1,15 @@
 <div class="container">
+  <h1 class="text-center" style="margin-top: 45px;"><%= (t'new_page.h1')%></h1>
+
   <div id="signupbox" style=" margin-top:50px" class="mainbox col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2">
     <div class="panel panel-info">
       <div class="panel-heading">
-          <div class="panel-title"><%= (t'buttons_t.edit' ) + ' ' +  @agency.name.capitalize %></div>
+          <div class="panel-title" style="display: flex; align-items: center;justify-content: center;"><%= @agency.name.capitalize %></div>
           <div style="float:right; font-size: 85%; position: relative; top:-10px"></div>
-      </div> 
-      <div class="panel-inline-body">
+      </div>
+      <div class="panel-body">
         <%= render 'form' %>
-      </div> <%#end panel-body%>
-    </div> <%# end of panel-info div%>
-  </div> <%# end of titlebox %>
-</div> 
-
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/agencies/edit.html.erb
+++ b/app/views/agencies/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1 class="text-center" style="margin-top: 45px;"><%= (t'new_page.h1')%></h1>
+  <h1 class="text-center" style="margin-top: 45px;"><%= (t'edit_page.h1')%></h1>
 
   <div id="signupbox" style=" margin-top:50px" class="mainbox col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2">
     <div class="panel panel-info">

--- a/app/views/agencies/new.html.erb
+++ b/app/views/agencies/new.html.erb
@@ -11,10 +11,10 @@
         <div class="individual-import">
           <%= render 'form' %>
         </div>
-      </div> <%#end panel-body%>
-    </div> <%# end of panel-info div%>
+      </div>
+    </div>
 
-  </div> <%# end of titlebox %>
+  </div>
   <div id="signupbox" style="margin-top:50px;" class="mainbox col-md-4 col-sm-4">
     <h3>Import Organizations</h3>
     <%= form_tag import_agencies_path, multipart: true do %>
@@ -23,4 +23,3 @@
     <% end %>
   </div>
 </div>
-<%# render 'form' %>

--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -61,7 +61,7 @@
     <div class="dropdown-menu pl-1" aria-labelledby="navbarDropdown">
       <% if policy(Agency).new? %>
         <%= link_to new_agency_path do %>
-          <%= fa_icon "plus", text: (t'new_page.h1')%>
+          <%= fa_icon "plus", text: "Organization"%>
         <% end %>
       <% end %>
       <div class="dropdown-divider"></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,12 +171,12 @@ en:
   views_index:
     h1: Organizations
   new_page:
-    h1: Organization
+    h1: Create Organization
     h2: Organization Update Request
     submit: Create Organization
     fill_fields: "Fill the following fields"
   edit_page:
-   h1: Edit Organization
+   h1: Update Organization
    submit: Save changes
   show_page:
     address: "Address:"


### PR DESCRIPTION
- Removed `button` class from the categories checkbox on agency forms.
- Removed unnecessary comments from agency views
- Improved translations for form titles
Thank you @micronix !

<img width="1004" alt="Screen Shot 2021-08-31 at 12 55 28 PM" src="https://user-images.githubusercontent.com/25111094/131544612-36ea0266-da86-43c8-ba8d-dad38c34f37a.png">
