### PR TITLE
nrai/send emails to admins on request submissions/cc 52

### DIFF
--- a/app/controllers/agency_update_requests_controller.rb
+++ b/app/controllers/agency_update_requests_controller.rb
@@ -19,6 +19,7 @@ class AgencyUpdateRequestsController < ApplicationController
       @agency_update_request.nombre = nil
     end
     if @agency_update_request.save
+      AgencyUpdateMailer.new_agency_update_email(@agency, @agency_update_request).deliver_later
       redirect_to confirmation_path
     else
       render 'new'

--- a/app/controllers/agency_update_requests_controller.rb
+++ b/app/controllers/agency_update_requests_controller.rb
@@ -15,12 +15,11 @@ class AgencyUpdateRequestsController < ApplicationController
 
   def create
     @agency_update_request = @agency.agency_update_requests.new(ag_params)
-    @admins = User.where(role: "admin")
     if ag_params[:nombre].blank?
       @agency_update_request.nombre = nil
     end
     if @agency_update_request.save
-      AgencyUpdateMailer.new_agency_update_email(@agency, @agency_update_request, @admins).deliver_later
+      AgencyUpdateMailer.with(agency: @agency, agency_update_request: @agency_update_request).new_agency_update_email.deliver_later
       redirect_to confirmation_path
     else
       render 'new'

--- a/app/controllers/agency_update_requests_controller.rb
+++ b/app/controllers/agency_update_requests_controller.rb
@@ -53,6 +53,8 @@ class AgencyUpdateRequestsController < ApplicationController
         if ag_params[:nombre].blank?
           @agency.update(nombre: nil)
         end
+
+        AgencyUpdateMailer.with(agency_update_request: @agency_update_request).agency_update_approval_email.deliver_later
         flash.notice = (t'flash_notice.approve-success')
         redirect_to agency_path(@agency)
       elsif params["status"] == "rejected"

--- a/app/controllers/agency_update_requests_controller.rb
+++ b/app/controllers/agency_update_requests_controller.rb
@@ -15,11 +15,12 @@ class AgencyUpdateRequestsController < ApplicationController
 
   def create
     @agency_update_request = @agency.agency_update_requests.new(ag_params)
+    @admins = User.where(role: "admin")
     if ag_params[:nombre].blank?
       @agency_update_request.nombre = nil
     end
     if @agency_update_request.save
-      AgencyUpdateMailer.new_agency_update_email(@agency, @agency_update_request).deliver_later
+      AgencyUpdateMailer.new_agency_update_email(@agency, @agency_update_request, @admins).deliver_later
       redirect_to confirmation_path
     else
       render 'new'

--- a/app/mailers/agency_update_mailer.rb
+++ b/app/mailers/agency_update_mailer.rb
@@ -1,8 +1,10 @@
 class AgencyUpdateMailer < ApplicationMailer
+  default cc: -> { User.where(role: 'admin').pluck(:email) }
+
   def new_agency_update_email
     @agency = params[:agency]
     @aur = params[:agency_update_request]
 
-    mail(from: @agency.email, cc: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
+    mail(from: @agency.email, to: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
   end
 end

--- a/app/mailers/agency_update_mailer.rb
+++ b/app/mailers/agency_update_mailer.rb
@@ -1,9 +1,8 @@
 class AgencyUpdateMailer < ApplicationMailer
-  def new_agency_update_email(agency, aur, admins)
-    @agency = agency
-    @aur = aur
-    @admins = admins
+  def new_agency_update_email
+    @agency = params[:agency]
+    @aur = params[:agency_update_request]
 
-    mail(from: agency.email, to: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
+    mail(from: @agency.email, cc: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
   end
 end

--- a/app/mailers/agency_update_mailer.rb
+++ b/app/mailers/agency_update_mailer.rb
@@ -7,4 +7,10 @@ class AgencyUpdateMailer < ApplicationMailer
     mail(from: @agency.email, to: 'admin@saf-unite.org', cc: (Proc.new { User.where(role: 'admin').pluck(:email) }).call, subject: 'You got a new organization update request!')
   end
 
+  def agency_update_approval_email
+    @aur = params[:agency_update_request]
+    attachments.inline['SAFLogo1.png'] = File.read('/Users/nrai/Documents/conectate-carolina/app/assets/images/SAFLogo1.png')
+
+    mail(from: 'admin@saf-unite.org', to: @aur.email, subject: 'Your organization information is updated!')
+  end
 end

--- a/app/mailers/agency_update_mailer.rb
+++ b/app/mailers/agency_update_mailer.rb
@@ -1,0 +1,8 @@
+class AgencyUpdateMailer < ApplicationMailer
+  def new_agency_update_email(agency)
+    @agency = agency
+    @aur = params[:agency_update_request]
+
+    mail(from: agency.email, to: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
+  end
+end

--- a/app/mailers/agency_update_mailer.rb
+++ b/app/mailers/agency_update_mailer.rb
@@ -1,7 +1,7 @@
 class AgencyUpdateMailer < ApplicationMailer
-  def new_agency_update_email(agency)
+  def new_agency_update_email(agency, aur)
     @agency = agency
-    @aur = params[:agency_update_request]
+    @aur = aur
 
     mail(from: agency.email, to: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
   end

--- a/app/mailers/agency_update_mailer.rb
+++ b/app/mailers/agency_update_mailer.rb
@@ -1,10 +1,10 @@
 class AgencyUpdateMailer < ApplicationMailer
-  default cc: -> { User.where(role: 'admin').pluck(:email) }
 
   def new_agency_update_email
     @agency = params[:agency]
     @aur = params[:agency_update_request]
 
-    mail(from: @agency.email, to: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
+    mail(from: @agency.email, to: 'admin@saf-unite.org', cc: (Proc.new { User.where(role: 'admin').pluck(:email) }).call, subject: 'You got a new organization update request!')
   end
+
 end

--- a/app/mailers/agency_update_mailer.rb
+++ b/app/mailers/agency_update_mailer.rb
@@ -1,7 +1,8 @@
 class AgencyUpdateMailer < ApplicationMailer
-  def new_agency_update_email(agency, aur)
+  def new_agency_update_email(agency, aur, admins)
     @agency = agency
     @aur = aur
+    @admins = admins
 
     mail(from: agency.email, to: 'admin@saf-unite.org', subject: 'You got a new organization update request!')
   end

--- a/app/views/agency_update_mailer/agency_update_approval_email.html.erb
+++ b/app/views/agency_update_mailer/agency_update_approval_email.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+    <style media="screen">
+      #my-style{ padding-left: 25px;}
+    </style>
+  </head>
+  <body>
+    <p id="my-style">Your organization information is updated!</p>
+    <p id="my-style">Please contact us if you have any question or concern.</p><br/>
+
+
+    <p><%= image_tag attachments['SAFLogo1.png'].url, alt: 'SAF Logo'%><br/>
+    <span id="my-style">Phone: <a href="tel:(919) 660-3652">(919) 660-3652</a></span><br/>
+    <span id="my-style">Email: <a href = "mailto:admin@saf-unite.org">admin@saf-unite.org</a></span></p>
+  </body>
+</html>

--- a/app/views/agency_update_mailer/agency_update_approval_email.text.erb
+++ b/app/views/agency_update_mailer/agency_update_approval_email.text.erb
@@ -1,0 +1,7 @@
+Your organization information is updated!
+Please contact us if you have any question or concern.
+
+Student Aaction with Farmworkers
+
+Phone: (919) 660-3652
+Email: admin@saf-unite.org

--- a/app/views/agency_update_mailer/new_agency_update_email.html.erb
+++ b/app/views/agency_update_mailer/new_agency_update_email.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>You got a new organization update request from <%= @aur.name %>!</p>
+    <p>
+    Update Request Details<br>
+    --------------------------
+    </p>
+    <p>Organization Name: <%= @aur.name %></p>
+    <p>Submitted by: <%= @aur.submitted_by %></p>
+    <p>Email: <%= @aur.submitter_email %></p>
+    <p>Phone: <%= @aur.phone %></p>
+  </body>
+</html>

--- a/app/views/agency_update_mailer/new_agency_update_email.html.erb
+++ b/app/views/agency_update_mailer/new_agency_update_email.html.erb
@@ -4,12 +4,12 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <p>You got a new organization update request from <%= @aur.name %>!</p>
+    <p>You got a new organization update request from <%= @agency.name %>!</p>
     <p>
     Update Request Details<br>
     --------------------------
     </p>
-    <p>Organization Name: <%= @aur.name %></p>
+    <p>Organization Name: <%= @agency.name %></p>
     <p>Submitted by: <%= @aur.submitted_by %></p>
     <p>Phone: <a href="tel:<%=@aur.phone%>"><%= @aur.phone %></a></p>
     <p>Email: <a href = "mailto:<%=@aur.submitter_email%>"><%= @aur.submitter_email %></a></p>

--- a/app/views/agency_update_mailer/new_agency_update_email.html.erb
+++ b/app/views/agency_update_mailer/new_agency_update_email.html.erb
@@ -11,7 +11,7 @@
     </p>
     <p>Organization Name: <%= @aur.name %></p>
     <p>Submitted by: <%= @aur.submitted_by %></p>
-    <p>Email: <%= @aur.submitter_email %></p>
-    <p>Phone: <%= @aur.phone %></p>
+    <p>Phone: <a href="tel:<%=@aur.phone%>"><%= @aur.phone %></a></p>
+    <p>Email: <a href = "mailto:<%=@aur.submitter_email%>"><%= @aur.submitter_email %></a></p>
   </body>
 </html>

--- a/app/views/agency_update_mailer/new_agency_update_email.text.erb
+++ b/app/views/agency_update_mailer/new_agency_update_email.text.erb
@@ -1,0 +1,10 @@
+You got a new organization update request from <%= @aur.name %>!
+===============================================
+
+Update Request Details:
+--------------------------
+
+Organization Name: <%= @aur.name %>
+Submitted by: <%= @aur.submitted_by %>
+Email: <%= @aur.submitter_email %>
+Phone: <%= @aur.phone %>

--- a/app/views/agency_update_mailer/new_agency_update_email.text.erb
+++ b/app/views/agency_update_mailer/new_agency_update_email.text.erb
@@ -6,5 +6,5 @@ Update Request Details:
 
 Organization Name: <%= @aur.name %>
 Submitted by: <%= @aur.submitted_by %>
-Email: <%= @aur.submitter_email %>
 Phone: <%= @aur.phone %>
+Email: <%= @aur.submitter_email %>

--- a/app/views/agency_update_mailer/new_agency_update_email.text.erb
+++ b/app/views/agency_update_mailer/new_agency_update_email.text.erb
@@ -1,10 +1,10 @@
-You got a new organization update request from <%= @aur.name %>!
+You got a new organization update request from <%= @agency.name %>!
 ===============================================
 
 Update Request Details:
 --------------------------
 
-Organization Name: <%= @aur.name %>
+Organization Name: <%= @agency.name %>
 Submitted by: <%= @aur.submitted_by %>
 Phone: <%= @aur.phone %>
 Email: <%= @aur.submitter_email %>

--- a/spec/mailers/agency_update_mailer_spec.rb
+++ b/spec/mailers/agency_update_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgencyUpdateMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agency_update_mailer_preview.rb
+++ b/spec/mailers/previews/agency_update_mailer_preview.rb
@@ -1,0 +1,11 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agency_update_mailer
+class AgencyUpdateMailerPreview < ActionMailer::Preview
+  def new_agency_update_email
+    # Set up a temporary agency update request for the preview
+    agency = Agency.create(name: "Ctd", address: "201 W Main st.", city: "Durham", state: "NC", zipcode: "27701", email: "me@codethedream.org")
+    aur = AgencyUpdateRequest.new(agency_id: agency.id, name: "Code the Dream", address: "201 W Main st.", city: "Durham", state: "NC", zipcode: "27701",
+                                  phone: "919-989-0184", submitted_by: "Michael", submitter_email: "michael@codethedream.org")
+
+    AgencyUpdateMailer.with(agency_update_request: aur).new_agency_update_email(agency)
+  end
+end


### PR DESCRIPTION
- Added a mailer to receive `email notifications` when an organization submits org update requests
- Added a mailer method to send `email notifications` when `SAF admins` approves orgs information updates
- Embedded SAF logo into the email template when sending emails to orgs
Thank you @micronix !!

https://user-images.githubusercontent.com/25111094/136277273-32b9c3d2-9d3c-461f-bbec-1c4664596842.mov



