### PR TITLE
nrai/display number of people who read a message

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -32,6 +32,6 @@ class Api::V1::MessagesController < ApplicationController
 
   private
     def device_message_params
-      params.require(:device_message).permit(:message_id, :ticket_id, error_messages: {})
+      params.require(:device_message).permit(:message_id)
     end
 end

--- a/app/views/messages/_messages.html.erb
+++ b/app/views/messages/_messages.html.erb
@@ -57,6 +57,9 @@
                 </p>
               </div>
             </div>
+            <span>
+              <label><%= message.devices.count %></label> views
+            </span>
             <div class="controls col-sm-5 col-md-3", id="buttons">
               <div class="edit-delete-buttons">
                 <%= link_to edit_message_path(message), class: "btn btn-sm btn-secondary" do %>


### PR DESCRIPTION
- Display `number` of people who `viewed` a `push notification` from their devices
- Removed unnecessary `attributes` from messages `strong parameter`
Thank you @micronix !!

<img width="1211" alt="Screen Shot 2021-12-06 at 9 45 12 PM" src="https://user-images.githubusercontent.com/25111094/144957201-46098856-951e-4655-bdb0-17546974a678.png">


