### PR TITLE
Record messages read only if the device exists

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -22,16 +22,20 @@ class Api::V1::MessagesController < ApplicationController
 
   def create
     device = Device.find_by_token(params[:device_message][:token]) if params[:device_message][:token].present?
-    @device_message = DeviceMessage.find_by(device_id: device.id, message_id: params[:device_message][:message_id]) unless device.nil?
-    modified_params = device_message_params
-    modified_params[:device_id] = device.id
-    modified_params[:status] = "opened"
-    @device_message = DeviceMessage.create!(modified_params) if @device_message.nil?
-    json_response(@device_message, :created)
+    if device
+      @device_message = DeviceMessage.find_by(device_id: device.id, message_id: params[:device_message][:message_id])
+      modified_params = device_message_params
+      modified_params[:device_id] = device.id
+      modified_params[:status] = "opened"
+      @device_message = DeviceMessage.create!(modified_params) if @device_message.nil?
+      json_response(@device_message, :created)
+    else
+      render json: { error: 'Device not found.' }
+    end
   end
 
   private
     def device_message_params
-      params.require(:device_message).permit(:message_id)
+      params.require(:device_message).permit(:message_id, :token, :device_id)
     end
 end


### PR DESCRIPTION
- Fixed the bug on recording `messages` being `read` by users by adding a check to see if the `device` exists
- Added missing attributes on `strong params`

Thank you @micronix !!