### PR TITLE
Fix agency update requests disappearance bug by re-assigning status

### DIFF
--- a/app/controllers/agency_update_requests_controller.rb
+++ b/app/controllers/agency_update_requests_controller.rb
@@ -61,6 +61,7 @@ class AgencyUpdateRequestsController < ApplicationController
         flash.alert = (t'flash_notice.reject-success')
         redirect_to agency_update_requests_path
       else
+        @agency_update_request.update(status: 'submitted')
         flash.notice = (t'flash_notice.save-success')
         redirect_to (request.referrer || agency_update_requests_url)
       end


### PR DESCRIPTION
- Fixed a bug on updating an `agency update request` where when just updating it's data but not `approving` or `rejecting` it used to get `nil` value assigned and it used to get lost from the list (fix was to re-assign its status to `submitted`)

Thanks @micronix !!