### PR TITLE
Remove exception_notification gem from app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'underscore-rails', '~> 1.8', '>= 1.8.3'
 gem 'mail_form'
 gem 'figaro'
 gem "autoprefixer-rails"
-gem 'exception_notification'
 gem 'redcarpet'
 gem "unicode-display_width"
 gem 'will_paginate', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,9 +126,6 @@ GEM
     erubi (1.10.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    exception_notification (4.4.3)
-      actionmailer (>= 4.0, < 7)
-      activesupport (>= 4.0, < 7)
     execjs (2.7.0)
     exponent-server-sdk (0.1.0)
       typhoeus
@@ -390,7 +387,6 @@ DEPENDENCIES
   devise
   devise-i18n
   dotenv-rails
-  exception_notification
   exponent-server-sdk
   factory_bot_rails
   ffaker


### PR DESCRIPTION
Hi @micronix ,

Sorry I forgot to remove `exception_notification` gem as part of the previous ticket. This PR does it.

Thank you,